### PR TITLE
Probe - register ProbeFilter

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/ProbeDeploymentProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/ProbeDeploymentProcessor.java
@@ -146,7 +146,7 @@ public class ProbeDeploymentProcessor implements DeploymentUnitProcessor {
         if (webMetaData.getFilterMappings() == null) {
             webMetaData.setFilterMappings(new ArrayList<FilterMappingMetaData>());
         }
-        webMetaData.getFilterMappings().add(PROBE_FILTER_MAPPING);
+        webMetaData.getFilterMappings().add(0, PROBE_FILTER_MAPPING);
 
         // Injection into servlet and filter
         final EEModuleDescription module = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);


### PR DESCRIPTION
`org.jboss.weld.probe.ProbeFilter` is hardcoded - should be replaced with `ProbeFilter.class.getName()` once 3.0.0.Alpha8 is released.
